### PR TITLE
fix: use window.CONFIG in config.js to ensure config is applied (v1_11foto6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/family-tree/issues/35
-Your prepared branch: issue-35-8a0fba333bdf
-Your prepared working directory: /tmp/gh-issue-solver-1772311402087
-Your forked repository: konard/bpmbpm-family-tree
-Original repository (upstream): bpmbpm/family-tree
-
-Proceed.


### PR DESCRIPTION
Fixes #35.

## Root cause

`config.js` used `const CONFIG = {...}` at script top-level. In modern JavaScript, `const` (and `let`) at the top level of a script create a **lexical global binding** but do **NOT** add a property to the `window` object. This means `window.CONFIG` was always `undefined` when `loadConfig()` in `index.html` checked for it:

```js
// This check always failed — window.CONFIG was always undefined:
if (typeof window.CONFIG === 'object' && window.CONFIG !== null) {
    config = window.CONFIG;
}
```

As a result, all config parameters (width, height, fontsize, colors, picDirType, etc.) were silently ignored and the hardcoded default values were used in DOT output:
- `width=2` instead of `1.1`
- `height=1.83` instead of `1.9`
- `fontsize=8.8` (= 11 × 0.8 default) instead of `9.9` (= 11 × 0.9 from config)
- `fillcolor="#a3c4f3"` instead of `"lightsteelblue"`
- `picDirType` was `"relative"` instead of `"relativeGraphvizOnline"` — so DOT panel showed relative paths instead of absolute URLs

In contrast, `var` at top-level **does** add to `window`. This is a well-known JavaScript scoping difference between `var` and `const`/`let`.

## Fix

Changed `const CONFIG = {...}` → `window.CONFIG = {...}` in `config.js`.

This makes `window.CONFIG` accessible as expected by `loadConfig()`.

## Changed files

- **ver1/config.js** — `const CONFIG` → `window.CONFIG` (1 line change)

## Verified

Tested locally with HTTP server. After the fix:
- `window.CONFIG` is correctly set (`typeof window.CONFIG === "object"`)
- DOT output uses config values: `width=1.1, height=1.9, fontsize=9.9`
- Colors from config applied: `fillcolor="lightsteelblue"`, `color="darkslategray"`
- `relativeGraphvizOnline` mode active: DOT panel shows absolute GitHub Pages URLs for photos

---
*This PR was created automatically by the AI issue solver*