### PR TITLE
feat(v2): add service_foto_github_v2.html with extra files check via GitHub API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/bpmbpm/family-tree/issues/62
-Your prepared branch: issue-62-864c194a0f62
-Your prepared working directory: /tmp/gh-issue-solver-1772714752426
-Your forked repository: konard/bpmbpm-family-tree
-Original repository (upstream): bpmbpm/family-tree
-
-Proceed.


### PR DESCRIPTION
## Проблема

В существующем `service_foto_github.html` была следующая заглушка:
> «Проверка лишних файлов невозможна в онлайн-режиме (нет доступа к папке).»

Браузер не может получить список файлов в папке без серверной поддержки, поэтому определить «лишние файлы» (файлы в папке, не указанные в колонке `idA`) было невозможно.

Closes #62

## Решение

Создан файл `ver2/service_foto_github_v2.html`, который использует **GitHub Contents API** (`https://api.github.com/repos/{owner}/{repo}/contents/{path}`) для получения списка файлов в папке. Это позволяет:

1. Получить список реальных файлов в каждой папке (`foto_person`, `foto_family`, и т.д.) через публичный GitHub API
2. Сравнить с набором значений `idA` из Excel-файла
3. Вывести предупреждение, если в папке есть файлы, **не указанные в `idA`** («лишние файлы»)

## Изменения

- **Новый файл:** `ver2/service_foto_github_v2.html`
- JSON-конфиг расширен тремя параметрами:
  - `githubRepo` — owner/repo (например, `bpmbpm/family-tree`)
  - `githubBranch` — ветка (по умолчанию `main`)
  - `githubBasePath` — путь к базовой папке внутри репозитория (например, `ver2`)
- Добавлена функция `getGithubFolderFiles()` — асинхронный запрос к GitHub API
- В отчёт каждого листа добавлен блок **«Лишние файлы»**:
  - `✅ Лишних файлов не найдено.` — если всё в порядке
  - `⚠️ Лишние файлы в папке (не указаны в idA) — N:` — с перечнем файлов
  - `ℹ️ Проверка лишних файлов: ...` — при ошибке или незаполненных параметрах
- Сохранена вся существующая функциональность (проверка отсутствующих файлов, отображение пути к папке, декодирование русских имён файлов)

## Тест

Файл доступен после деплоя на GitHub Pages по адресу:
`https://bpmbpm.github.io/family-tree/ver2/service_foto_github_v2.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)