### PR TITLE
ver7: fix album open on desktop (issue #124)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-20T08:09:37.154Z for PR creation at branch issue-124-c260327ec5ef for issue https://github.com/bpmbpm/family-tree/issues/124

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-20T08:09:37.154Z for PR creation at branch issue-124-c260327ec5ef for issue https://github.com/bpmbpm/family-tree/issues/124

--- a/ver7/index.html
+++ b/ver7/index.html
@@ -490,6 +490,14 @@
             };
 
             window.showAlbumGallery = async function() {
+                // В режиме file:// (desktop) открываем папку album/ напрямую в браузере
+                if (window.location.protocol === 'file:') {
+                    var pageUrl = window.location.href;
+                    var albumFolderUrl = pageUrl.substring(0, pageUrl.lastIndexOf('/') + 1) + 'album/';
+                    window.open(albumFolderUrl, '_blank');
+                    return;
+                }
+
                 const PANEL_ID = 'album-gallery-panel';
                 const container = document.getElementById('properties-panels-container');
                 if (!container) return;
@@ -506,39 +514,7 @@
                     }
                 } catch (e) { /* ignore */ }
 
-                // В режиме file:// fetch заблокирован браузером — пробуем XMLHttpRequest асинхронно
-                if (fileNames.length === 0 && window.location.protocol === 'file:') {
-                    try {
-                        await new Promise(function(resolve) {
-                            var xhr = new XMLHttpRequest();
-                            xhr.open('GET', 'album/list.md', true);
-                            xhr.onload = function() {
-                                if (xhr.status === 200 || xhr.status === 0) {
-                                    var lines = xhr.responseText.split('\n').map(function(l) { return l.trim(); }).filter(function(l) { return l && l !== 'list'; });
-                                    if (lines.length > 0) fileNames = lines;
-                                }
-                                resolve();
-                            };
-                            xhr.onerror = function() { resolve(); };
-                            xhr.send();
-                        });
-                    } catch (e) { /* ignore */ }
-                }
-
-                // Если асинхронный XHR тоже не сработал — пробуем синхронный XHR (как в loadConfig)
-                if (fileNames.length === 0 && window.location.protocol === 'file:') {
-                    try {
-                        var xhrSync = new XMLHttpRequest();
-                        xhrSync.open('GET', 'album/list.md', false);
-                        xhrSync.send();
-                        if (xhrSync.status === 200 || xhrSync.status === 0) {
-                            var syncLines = xhrSync.responseText.split('\n').map(function(l) { return l.trim(); }).filter(function(l) { return l && l !== 'list'; });
-                            if (syncLines.length > 0) fileNames = syncLines;
-                        }
-                    } catch (e) { /* ignore */ }
-                }
-
-                // Если fetch не сработал (file:// protocol) или список пуст, пробуем GitHub API
+                // Если fetch не сработал или список пуст, пробуем GitHub API
                 if (fileNames.length === 0 && window.location.protocol !== 'file:') {
                     try {
                         const hostname = window.location.hostname;


### PR DESCRIPTION
## Summary

- Fixes the recurring issue where clicking **📷 Альбомы (album)** on desktop (file:// protocol) always showed *"Файлы не найдены в папке album/"* because browsers block XHR/fetch for local files.
- On desktop (`file://` protocol), the button now directly opens the `album/` folder URL in a new browser tab (e.g. `file:///C:/path/to/ver7/album/`), letting the user browse and select files using the browser's native file listing.
- On HTTP/HTTPS (GitHub Pages etc.) the existing gallery panel behaviour is unchanged.

## Root cause

Previous attempts used `XMLHttpRequest` (async and sync) to load `album/list.md` on `file://`. Modern browsers (Chrome, Edge, Firefox) block cross-origin and local-file XHR requests, so `fileNames` always remained empty, producing the "not found" message.

## Solution

Detect `window.location.protocol === 'file:'` at the top of `showAlbumGallery()` and immediately open the album folder URL constructed from the current page's URL:

```js
if (window.location.protocol === 'file:') {
    var pageUrl = window.location.href;
    var albumFolderUrl = pageUrl.substring(0, pageUrl.lastIndexOf('/') + 1) + 'album/';
    window.open(albumFolderUrl, '_blank');
    return;
}
```

This removes the dead XHR fallback code and solves the problem cleanly without requiring `list.md` at all.

## Test plan
- [ ] Open `ver7/index.html` locally via `file://` in browser
- [ ] Click **📂 Открыть файл ▾ → 📷 Альбомы (album)**
- [ ] Verify a new tab opens showing the contents of the `album/` folder
- [ ] Verify clicking files (JPG, PDF, DOCX, MD) in that tab opens them
- [ ] Open on GitHub Pages and verify the gallery panel still works normally

Fixes bpmbpm/family-tree#124

🤖 Generated with [Claude Code](https://claude.com/claude-code)